### PR TITLE
Package version as revision

### DIFF
--- a/src/com/tw/go/plugin/nuget/NuGetFeedDocument.java
+++ b/src/com/tw/go/plugin/nuget/NuGetFeedDocument.java
@@ -61,7 +61,7 @@ public class NuGetFeedDocument {
         }
         if (getEntries().getLength() > 1)
             throw new NuGetException(String.format("Multiple entries in feed for %s %s", getEntryTitle(), getPackageVersion()));
-        PackageRevision result = new PackageRevision(getPackageLabel(), getPublishedDate(), getAuthor(), getReleaseNotes(), getProjectUrl());
+        PackageRevision result = new PackageRevision(getPackageVersion(), getPublishedDate(), getAuthor(), getReleaseNotes(), getProjectUrl());
         result.addData(NuGetPackageConfig.PACKAGE_LOCATION, getPackageLocation());
         result.addData(NuGetPackageConfig.PACKAGE_VERSION, getPackageVersion());
         return result;

--- a/test/fast/com/tw/go/plugin/nuget/NuGetFeedDocumentTest.java
+++ b/test/fast/com/tw/go/plugin/nuget/NuGetFeedDocumentTest.java
@@ -42,7 +42,7 @@ public class NuGetFeedDocumentTest {
         Document doc = builder.parse(new File("test" + File.separator + "fast" + File.separator + "nuget-good-feed.xml"));
         PackageRevision result = new NuGetFeedDocument(doc).getPackageRevision(false);
         assertThat(result.getUser(), is("Igor Pavlov"));
-        assertThat(result.getRevision(), is("7-Zip.CommandLine-9.20.0"));
+        assertThat(result.getRevision(), is("9.20.0"));
         assertThat(result.getRevisionComment(), is("revision comment line 1"));
         assertThat(result.getTimestamp(), is(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").parse("2013-06-09T15:36:30.807")));
         assertThat(result.getDataFor(NuGetPackageConfig.PACKAGE_LOCATION), is("https://nuget.org/api/v2/package/7-Zip.CommandLine/9.20.0"));


### PR DESCRIPTION
Currently the revision that is returned contains not only the package version but also the package title (id). That is not necessary and causes unpleasant side effects - i.e. when the revision is displayed in the pipeline history (http://serveurl:port/go/tab/pipeline/history/pipeline-name) it displays the package name (if it's long even only parts of it) and truncates the real version.
