### PR TITLE
Workaround for null ref exception for feeds with missing fields

### DIFF
--- a/src/com/tw/go/plugin/nuget/NuGetFeedDocument.java
+++ b/src/com/tw/go/plugin/nuget/NuGetFeedDocument.java
@@ -34,9 +34,7 @@ public class NuGetFeedDocument {
         Element element = firstOf(properties);
         NodeList elementsByTagNameNS = element.getElementsByTagNameNS(SCHEMA_ADO_DATASERVICES, name);
         Node item = elementsByTagNameNS.item(0);
-        if (item == null)
-            return "";
-        return item.getTextContent();
+        return item == null ? "" : item.getTextContent();
     }
 
     private NodeList getProperties() {

--- a/src/com/tw/go/plugin/nuget/NuGetFeedDocument.java
+++ b/src/com/tw/go/plugin/nuget/NuGetFeedDocument.java
@@ -4,6 +4,7 @@ import com.thoughtworks.go.plugin.api.material.packagerepository.PackageRevision
 import com.tw.go.plugin.nuget.config.NuGetPackageConfig;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.util.Date;
@@ -30,7 +31,12 @@ public class NuGetFeedDocument {
     }
 
     private String getProperty(NodeList properties, String name) {
-        return firstOf(properties).getElementsByTagNameNS(SCHEMA_ADO_DATASERVICES, name).item(0).getTextContent();
+        Element element = firstOf(properties);
+        NodeList elementsByTagNameNS = element.getElementsByTagNameNS(SCHEMA_ADO_DATASERVICES, name);
+        Node item = elementsByTagNameNS.item(0);
+        if (item == null)
+            return "";
+        return item.getTextContent();
     }
 
     private NodeList getProperties() {
@@ -69,7 +75,7 @@ public class NuGetFeedDocument {
 
     private String getReleaseNotes() {
         String releaseNotes = getProperty(getProperties(), "ReleaseNotes");
-        if (releaseNotes == null || releaseNotes.trim().isEmpty()) return null;
+        if (releaseNotes == null || releaseNotes.trim().isEmpty()) return "";
         return firstNonEmptyLine(releaseNotes);
     }
 
@@ -79,12 +85,12 @@ public class NuGetFeedDocument {
             if (!line.trim().isEmpty())
                 return line.trim();
         }
-        return null;
+        return "";
     }
 
     private String getProjectUrl() {
         String projectUrl = getProperty(getProperties(), "ProjectUrl");
-        if (projectUrl == null || projectUrl.trim().isEmpty()) return null;
+        if (projectUrl == null || projectUrl.trim().isEmpty()) return "";
         return firstNonEmptyLine(projectUrl);
     }
 

--- a/test/fast/com/tw/go/plugin/nuget/NuGetFeedDocumentTest.java
+++ b/test/fast/com/tw/go/plugin/nuget/NuGetFeedDocumentTest.java
@@ -48,4 +48,20 @@ public class NuGetFeedDocumentTest {
         assertThat(result.getDataFor(NuGetPackageConfig.PACKAGE_LOCATION), is("https://nuget.org/api/v2/package/7-Zip.CommandLine/9.20.0"));
         assertThat(result.getDataFor(NuGetPackageConfig.PACKAGE_VERSION), is("9.20.0"));
     }
+
+    @Test
+    public void badFeed() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        DocumentBuilder builder;
+        builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(new File("test" + File.separator + "fast" + File.separator + "nuget-feed-with-missing-props.xml"));
+        PackageRevision result = new NuGetFeedDocument(doc).getPackageRevision(false);
+        assertThat(result.getUser(), is("Igor Pavlov"));
+        assertThat(result.getRevision(), is("7-Zip.CommandLine-9.20.0"));
+        assertThat(result.getRevisionComment(), is(""));
+        assertThat(result.getTimestamp(), is(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").parse("2013-06-09T15:36:30.807")));
+        assertThat(result.getDataFor(NuGetPackageConfig.PACKAGE_LOCATION), is("https://nuget.org/api/v2/package/7-Zip.CommandLine/9.20.0"));
+        assertThat(result.getDataFor(NuGetPackageConfig.PACKAGE_VERSION), is("9.20.0"));
+    }
 }

--- a/test/fast/com/tw/go/plugin/nuget/NuGetFeedDocumentTest.java
+++ b/test/fast/com/tw/go/plugin/nuget/NuGetFeedDocumentTest.java
@@ -60,6 +60,7 @@ public class NuGetFeedDocumentTest {
         assertThat(result.getUser(), is("Igor Pavlov"));
         assertThat(result.getRevision(), is("7-Zip.CommandLine-9.20.0"));
         assertThat(result.getRevisionComment(), is(""));
+        assertThat(result.getTrackbackUrl(), is(""));
         assertThat(result.getTimestamp(), is(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").parse("2013-06-09T15:36:30.807")));
         assertThat(result.getDataFor(NuGetPackageConfig.PACKAGE_LOCATION), is("https://nuget.org/api/v2/package/7-Zip.CommandLine/9.20.0"));
         assertThat(result.getDataFor(NuGetPackageConfig.PACKAGE_VERSION), is("9.20.0"));

--- a/test/fast/nuget-feed-with-missing-props.xml
+++ b/test/fast/nuget-feed-with-missing-props.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<feed xml:base="https://nuget.org/api/v2/" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">GetUpdates</title>
+  <id>https://nuget.org/api/v2/Search</id>
+  <updated>2013-07-02T06:15:49Z</updated>
+  <link rel="self" title="GetUpdates" href="GetUpdates"/>
+  <entry>
+        <id>https://nuget.org/api/v2/Packages(Id='7-Zip.CommandLine',Version='9.20.0')</id>
+    <title type="text">7-Zip.CommandLine</title>
+    <summary type="text"></summary>
+    <updated>2013-07-01T16:56:04Z</updated>
+        <author>
+            <name>Igor Pavlov</name>
+        </author>
+        <link rel="edit-media" title="V2FeedPackage" href="Packages(Id='7-Zip.CommandLine',Version='9.20.0')/$value" />
+        <link rel="edit" title="V2FeedPackage" href="Packages(Id='7-Zip.CommandLine',Version='9.20.0')" />
+        <category term="NuGetGallery.V2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+        <content type="application/zip" src="https://nuget.org/api/v2/package/7-Zip.CommandLine/9.20.0" />
+        <m:properties xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices">
+      <d:Version>9.20.0</d:Version>
+      <d:Created m:type="Edm.DateTime">2013-06-09T15:36:30.807</d:Created>
+      <d:Dependencies></d:Dependencies>
+      <d:Description>7-Zip is a file archiver with a high compression ratio.</d:Description>
+      <d:DownloadCount m:type="Edm.Int32">50</d:DownloadCount>
+      <d:IsLatestVersion m:type="Edm.Boolean">true</d:IsLatestVersion>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">true</d:IsAbsoluteLatestVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Language>en-US</d:Language>
+      <d:Published m:type="Edm.DateTime">2013-06-09T15:36:30.807</d:Published>
+      <d:PackageHash>yedSpc4eDl8rik0icFZwbf4uVoWgdX7/GcVNiAs6oDWpI4JWF0pERD0BK/CH/9yiIcJMmsAlopH1WxKiPjIurw==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">397408</d:PackageSize>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:Tags>7z 7zip 7-Zip zip</d:Tags>
+      <d:Title>7-Zip Command Line Version</d:Title>
+      <d:VersionDownloadCount m:type="Edm.Int32">50</d:VersionDownloadCount>
+      <d:MinClientVersion m:null="true"></d:MinClientVersion>
+    </m:properties>
+  </entry>
+</feed>

--- a/test/slow/com/tw/go/plugin/nuget/NuGetTest.java
+++ b/test/slow/com/tw/go/plugin/nuget/NuGetTest.java
@@ -23,7 +23,6 @@ public class NuGetTest {
         assertThat(result.getDataFor(PACKAGE_LOCATION), is("http://www.nuget.org/api/v2/package/RouteMagic.Mvc/1.2.0"));
     }
 
-
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 
@@ -39,7 +38,7 @@ public class NuGetTest {
         PackageRevision lastKnownVersion = new PackageRevision("1Password-1.0.9.288", new SimpleDateFormat("yyyy-MM-dd").parse("2013-03-21"), "xyz");
         lastKnownVersion.addData(PACKAGE_VERSION, "1.0.9.288");
         PackageRevision result = new NuGetPoller().poll(new NuGetParams(RepoUrl.create("http://chocolatey.org/api/v2", null, null), "1Password", null, null, lastKnownVersion, true));
-        assertThat(result.getDataFor(PACKAGE_VERSION), is("1.0.9.341"));
+        assertThat(result.getDataFor(PACKAGE_VERSION), is("4.2.0.548"));
     }
 
     @Test


### PR DESCRIPTION
This is a patch to work around Null reference exception that were raised if the target Nuget repo was hosted on the latest version of Artifactory.